### PR TITLE
Fix null reference error in VolumetricFogFeature

### DIFF
--- a/Runtime/VolumetricFogFeature.cs
+++ b/Runtime/VolumetricFogFeature.cs
@@ -215,7 +215,7 @@ namespace Andicraft.VolumetricFog
                     m_FogVolumesBuffer.SetData(structs);
                     renderMaterial.SetBuffer("_VFogVolumes", m_FogVolumesBuffer);
                 }
-                Shader.SetKeyword(kw_VolumesEnabled, vfog.volumes.Count != 0);
+                Shader.SetKeyword(kw_VolumesEnabled, vfog && vfog.volumes.Count != 0);
             }
 
             public override void Execute(ScriptableRenderContext context, ref RenderingData renderingData)


### PR DESCRIPTION
This fixes the null reference error found in https://github.com/Andicraft/VolumetricFog-URP2022/issues/2